### PR TITLE
use lib '.'; added to Makefile.PL so Module::Install can be found.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,3 +1,4 @@
+use lib ".";
 use inc::Module::Install;
 
 # Define metadata


### PR DESCRIPTION
cpan-prc.  Simple change to allow the module to build under more modern perls.