### PR TITLE
DSL::validate - force explicit file/string designation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ This is example of verification some text against 2 lines;
         My name is Outthentic!
     HERE
     
-    $otx->validate(<<'CHECK');
+    $otx->validate(from_string => <<'CHECK');
         Hello
         regexp: My\s+name\s+is\s+\S+
     CHECK
@@ -146,7 +146,7 @@ This is useful when debugging long check expressions:
     
     my $otx = Outthentic::DSL->new( 'A'x99 , { match_l  => 9 });
     
-    $otx->validate('A'x99);
+    $otx->validate(from_string => 'A'x99);
     
     print "status\tcheck\n";
     print "==========================\n";
@@ -183,7 +183,7 @@ Obligatory parameter is:
 
 Example:
 
-    $otx->validate(<<'CHECK');
+    $otx->validate(from_string => <<'CHECK');
 
       # there should be digits
       regexp: \d
@@ -241,7 +241,7 @@ Here is a simple example:
       My birth day is: 1977-04-16
     HERE
 
-    $otx->validate(<<'CHECK');
+    $otx->validate(from_string => <<'CHECK');
       HELLO
       regexp: \d\d\d\d-\d\d-\d\d
     CHECK
@@ -279,7 +279,7 @@ Plain text expressions define a lines an input text to contain.
       HELLO Outthentic !!!
     HERE
 
-    $otx->validate(<<'CHECK');
+    $otx->validate(from_string => <<'CHECK');
       I am ok
       HELLO Outthentic
     CHECK
@@ -307,7 +307,7 @@ Plain text expressions are case sensitive:
       I am ok
     HERE
 
-    $otx->validate(<<'CHECK');
+    $otx->validate(from_string => <<'CHECK');
       I am OK
     CHECK
 
@@ -341,7 +341,7 @@ Example:
       App Version Number: 1.1.10
     HERE
     
-    $otx->validate(<<'CHECK');
+    $otx->validate(from_string => <<'CHECK');
       regexp: \d\d\d\d-\d\d-\d\d # date in format of YYYY-MM-DD
       regexp: Name:\s+\w+ # name
       regexp: App Version Number:\s+\d+\.\d+\.\d+ # version number
@@ -376,7 +376,7 @@ Example:
         3 - for three
     HERE
     
-    $otx->validate(<<'CHECK');
+    $otx->validate(from_string => <<'CHECK');
     
     regexp: (\d+)\s+-\s+for\s+(\w+)
     
@@ -462,7 +462,7 @@ Sometimes you need to match a text against a _sequence of lines_ like in code be
       at the very end.
     HERE
 
-    $otx->validate(<<'CHECK');
+    $otx->validate(from_string => <<'CHECK');
 
       # this text block
       # consists of 5 strings
@@ -507,7 +507,7 @@ A negative example:
         at the very end.
     HERE
 
-    $otx->validate(<<'CHECK');
+    $otx->validate(from_string => <<'CHECK');
 
       # this text block
       # consists of 5 strings
@@ -568,7 +568,7 @@ By default, if *language* is no set Perl language is assumed. Here is example:
     
     my $otx = Outthentic::DSL->new('hello');
     
-    $otx->validate(<<'CHECK');
+    $otx->validate(from_string => <<'CHECK');
       hello
       code: print "hi there!\n";
     CHECK
@@ -668,7 +668,7 @@ Here is simple example.
     
     my $otx = Outthentic::DSL->new('HELLO');
     
-    $otx->validate(<<'CHECK');
+    $otx->validate(from_string => <<'CHECK');
       generator: [ 'H', 'E', 'L', 'O' ];
     CHECK
 
@@ -734,7 +734,7 @@ Here is more complicated example using Perl language.
       bar value
     HERE
     
-    $otx->validate(<<'CHECK');
+    $otx->validate(from_string => <<'CHECK');
     
         generator: <<CODE
 

--- a/README.pod
+++ b/README.pod
@@ -177,7 +177,7 @@ This is example of verification some text against 2 lines;
         My name is Outthentic!
     HERE
     
-    $otx->validate(<<'CHECK');
+    $otx->validate(from_string => <<'CHECK');
         Hello
         regexp: My\s+name\s+is\s+\S+
     CHECK
@@ -235,7 +235,7 @@ This is useful when debugging long check expressions:
     
     my $otx = Outthentic::DSL->new( 'A'x99 , { match_l  => 9 });
     
-    $otx->validate('A'x99);
+    $otx->validate(from_string => 'A'x99);
     
     print "status\tcheck\n";
     print "==========================\n";
@@ -257,6 +257,7 @@ Default value is C<40>.
 =item *
 
 debug_mod - enable debug mode
+
 
 =over
 
@@ -308,7 +309,7 @@ a string with DSL code
 
 Example:
 
-    $otx->validate(<<'CHECK');
+    $otx->validate(from_string => <<'CHECK');
     
       # there should be digits
       regexp: \d
@@ -366,6 +367,7 @@ Blank lines
 =item *
 
 Check expressions:
+
 
 =over
 
@@ -437,7 +439,7 @@ Here is a simple example:
       My birth day is: 1977-04-16
     HERE
     
-    $otx->validate(<<'CHECK');
+    $otx->validate(from_string => <<'CHECK');
       HELLO
       regexp: \d\d\d\d-\d\d-\d\d
     CHECK
@@ -486,7 +488,7 @@ Plain text expressions define a lines an input text to contain.
       HELLO Outthentic !!!
     HERE
     
-    $otx->validate(<<'CHECK');
+    $otx->validate(from_string => <<'CHECK');
       I am ok
       HELLO Outthentic
     CHECK
@@ -513,7 +515,7 @@ Plain text expressions are case sensitive:
       I am ok
     HERE
     
-    $otx->validate(<<'CHECK');
+    $otx->validate(from_string => <<'CHECK');
       I am OK
     CHECK
     
@@ -547,7 +549,7 @@ Example:
       App Version Number: 1.1.10
     HERE
     
-    $otx->validate(<<'CHECK');
+    $otx->validate(from_string => <<'CHECK');
       regexp: \d\d\d\d-\d\d-\d\d # date in format of YYYY-MM-DD
       regexp: Name:\s+\w+ # name
       regexp: App Version Number:\s+\d+\.\d+\.\d+ # version number
@@ -599,7 +601,7 @@ Example:
         3 - for three
     HERE
     
-    $otx->validate(<<'CHECK');
+    $otx->validate(from_string => <<'CHECK');
     
     regexp: (\d+)\s+-\s+for\s+(\w+)
     
@@ -688,7 +690,7 @@ Sometimes you need to match a text against a I<sequence of lines> like in code b
       at the very end.
     HERE
     
-    $otx->validate(<<'CHECK');
+    $otx->validate(from_string => <<'CHECK');
     
       # this text block
       # consists of 5 strings
@@ -729,7 +731,7 @@ A negative example:
         at the very end.
     HERE
     
-    $otx->validate(<<'CHECK');
+    $otx->validate(from_string => <<'CHECK');
     
       # this text block
       # consists of 5 strings
@@ -789,7 +791,7 @@ By default, if I<language> is no set Perl language is assumed. Here is example:
     
     my $otx = Outthentic::DSL->new('hello');
     
-    $otx->validate(<<'CHECK');
+    $otx->validate(from_string => <<'CHECK');
       hello
       code: print "hi there!\n";
     CHECK
@@ -920,7 +922,7 @@ Here is simple example.
     
     my $otx = Outthentic::DSL->new('HELLO');
     
-    $otx->validate(<<'CHECK');
+    $otx->validate(from_string => <<'CHECK');
       generator: [ 'H', 'E', 'L', 'O' ];
     CHECK
     
@@ -982,7 +984,7 @@ Here is more complicated example using Perl language.
       bar value
     HERE
     
-    $otx->validate(<<'CHECK');
+    $otx->validate(from_string => <<'CHECK');
     
         generator: <<CODE
     

--- a/examples/captures.pl
+++ b/examples/captures.pl
@@ -7,7 +7,7 @@ my $otx = Outthentic::DSL->new(<<'HERE');
     3 - for three
 HERE
 
-$otx->validate(<<'CHECK');
+$otx->validate(from_string => <<'CHECK');
 
 regexp: (\d+)\s+-\s+for\s+(\w+)
 

--- a/examples/code-expression.pl
+++ b/examples/code-expression.pl
@@ -2,7 +2,7 @@ use Outthentic::DSL;
 
 my $otx = Outthentic::DSL->new('hello');
 
-$otx->validate(<<'CHECK');
+$otx->validate(from_string => <<'CHECK');
   hello
   code: print "hi there!\n";
 CHECK

--- a/examples/generator.pl
+++ b/examples/generator.pl
@@ -2,7 +2,7 @@ use Outthentic::DSL;
 
 my $otx = Outthentic::DSL->new('HELLO');
 
-$otx->validate(<<'CHECK');
+$otx->validate(from_string => <<'CHECK');
   generator: [ 'H', 'E', 'L', 'O' ];
 CHECK
 

--- a/examples/hello-world.pl
+++ b/examples/hello-world.pl
@@ -5,7 +5,7 @@ my $otx = Outthentic::DSL->new(<<HERE, { debug_mod => 0 });
     My name is Outthentic!
 HERE
 
-$otx->validate(<<'CHECK');
+$otx->validate(from_string => <<'CHECK');
     Hello
     regexp: My\s+name\s+is\s+\S+
 CHECK

--- a/examples/match_l.pl
+++ b/examples/match_l.pl
@@ -2,7 +2,7 @@ use Outthentic::DSL;
 
 my $otx = Outthentic::DSL->new( 'A'x99 , { match_l  => 9 });
 
-$otx->validate('A'x99);
+$otx->validate(from_string => 'A'x99);
 
 print "status\tcheck\n";
 print "==========================\n";

--- a/examples/perl-generator.pl
+++ b/examples/perl-generator.pl
@@ -9,7 +9,7 @@ my $otx = Outthentic::DSL->new(<<'HERE', { debug_mod => 0 });
   bar value
 HERE
 
-$otx->validate(<<'CHECK');
+$otx->validate(from_string => <<'CHECK');
 
     generator: <<CODE
 

--- a/examples/plain-and-regexp-check.pl
+++ b/examples/plain-and-regexp-check.pl
@@ -6,7 +6,7 @@ my $otx = Outthentic::DSL->new(<<'HERE');
   My birth day is: 1977-04-16
 HERE
 
-$otx->validate(<<'CHECK');
+$otx->validate(from_string => <<'CHECK');
   HELLO
   regexp: \d\d\d\d-\d\d-\d\d
 CHECK

--- a/examples/plain-check-case-sensetive.pl
+++ b/examples/plain-check-case-sensetive.pl
@@ -4,7 +4,7 @@ my $otx = Outthentic::DSL->new(<<'HERE');
   I am ok
 HERE
 
-$otx->validate(<<'CHECK');
+$otx->validate(from_string => <<'CHECK');
   I am OK
 CHECK
 

--- a/examples/plain-check.pl
+++ b/examples/plain-check.pl
@@ -5,7 +5,7 @@ my $otx = Outthentic::DSL->new(<<'HERE');
   HELLO Outthentic !!!
 HERE
 
-$otx->validate(<<'CHECK');
+$otx->validate(from_string => <<'CHECK');
   I am ok
   HELLO Outthentic
 CHECK

--- a/examples/regex-check.pl
+++ b/examples/regex-check.pl
@@ -6,7 +6,7 @@ my $otx = Outthentic::DSL->new(<<'HERE');
   App Version Number: 1.1.10
 HERE
 
-$otx->validate(<<'CHECK');
+$otx->validate(from_string => <<'CHECK');
   regexp: \d\d\d\d-\d\d-\d\d # date in format of YYYY-MM-DD
   regexp: Name:\s+\w+ # name
   regexp: App Version Number:\s+\d+\.\d+\.\d+ # version number

--- a/examples/text-block-fail.pl
+++ b/examples/text-block-fail.pl
@@ -8,7 +8,7 @@ my $otx = Outthentic::DSL->new(<<'HERE');
     at the very end.
 HERE
 
-$otx->validate(<<'CHECK');
+$otx->validate(from_string => <<'CHECK');
 
   # this text block
   # consists of 5 strings

--- a/examples/text-block-pass.pl
+++ b/examples/text-block-pass.pl
@@ -8,7 +8,7 @@ my $otx = Outthentic::DSL->new(<<'HERE');
   at the very end.
 HERE
 
-$otx->validate(<<'CHECK');
+$otx->validate(from_string => <<'CHECK');
 
   # this text block
   # consists of 5 strings

--- a/t/01-plain-text.t
+++ b/t/01-plain-text.t
@@ -9,7 +9,7 @@ my $otx = Outthentic::DSL->new({
   output => 'OK'
 });
 
-$otx->validate('OK');
+$otx->validate(from_string => 'OK');
 
 #ok(1, "OK validated");
 


### PR DESCRIPTION
Outthentic::DSL->validate took 1 argument, if a file existed with that
name, it'd load that file line-wise and use the lines as a list of
checks.  Otherwise it'd either treat it as an arrayref of checks or a
single check.

This has a couple issues but the major one is that the argument is
ambiguous - if a program were calling $test->validate("OK"), an empty
file could be created in the working directory called 'OK' and cause
entirely different behavior.

Removing this ambiguity is not a change that can be done in a
backwards-compatible way.

If ->validate is passed a single argument, it will now warn with
instructions to use the proper two-argument syntax:

files:
  ...->validate(from_file => $filename);

string:
  ...->validate(from_string => $str);